### PR TITLE
Dahn add security role

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Fragments/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Fragments/ProfileFragment.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import ch.epfl.sweng.zuluzulu.OnFragmentInteractionListener;
 import ch.epfl.sweng.zuluzulu.R;
 import ch.epfl.sweng.zuluzulu.Structure.User;
+import ch.epfl.sweng.zuluzulu.Structure.UserRole;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -79,6 +80,10 @@ public class ProfileFragment extends Fragment implements OnFragmentInteractionLi
             builder.append(user.getLastNames().substring(0, 1).toUpperCase());
             builder.append(user.getLastNames().substring(1));
         }
+        if(user.hasRole(UserRole.ADMIN)){
+            builder.append(" ADMIN");
+        }
+
         String username = builder.toString();
 
         user_view.setText(username);

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Fragments/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Fragments/ProfileFragment.java
@@ -81,7 +81,7 @@ public class ProfileFragment extends Fragment implements OnFragmentInteractionLi
             builder.append(user.getLastNames().substring(1));
         }
         if(user.hasRole(UserRole.ADMIN)){
-            builder.append(" ADMIN");
+            builder.append(" - ADMIN");
         }
 
         String username = builder.toString();

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/MainActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/MainActivity.java
@@ -131,11 +131,10 @@ public class MainActivity extends AppCompatActivity implements OnFragmentInterac
      * Attach the drawer_view to the navigation view
      */
     private void updateMenuItems() {
+        navigationView.getMenu().clear();
         if (isAuthenticated()) {
-            navigationView.getMenu().clear();
             navigationView.inflateMenu(R.menu.drawer_view_user);
         } else {
-            navigationView.getMenu().clear();
             navigationView.inflateMenu(R.menu.drawer_view_guest);
         }
     }

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/Admin.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/Admin.java
@@ -1,8 +1,13 @@
 package ch.epfl.sweng.zuluzulu.Structure;
 
+/**
+ * This represent the Admin class
+ */
 public final class Admin extends AuthenticatedUser {
     protected Admin(String sciper, String gaspar, String email, String first_names, String last_names) {
         super(sciper, gaspar, email, first_names, last_names);
+
+        // Admin has role ADMIN
         addRole(UserRole.ADMIN);
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/Admin.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/Admin.java
@@ -1,0 +1,8 @@
+package ch.epfl.sweng.zuluzulu.Structure;
+
+public final class Admin extends AuthenticatedUser {
+    protected Admin(String sciper, String gaspar, String email, String first_names, String last_names) {
+        super(sciper, gaspar, email, first_names, last_names);
+        addRole(UserRole.ADMIN);
+    }
+}

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/AuthenticatedUser.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/AuthenticatedUser.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-public final class AuthenticatedUser extends User {
+public class AuthenticatedUser extends User {
 
     // Use sciper to check User (and not mail or gaspar)
     private final String sciper;
@@ -38,7 +38,6 @@ public final class AuthenticatedUser extends User {
 
         // Add role
         this.addRole(UserRole.USER);
-        this.addRole(UserRole.MODERATOR);
     }
 
     // TODO: Add a method to add/remove one Association to assos_id, same for chats and events

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/AuthenticatedUser.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/AuthenticatedUser.java
@@ -2,6 +2,7 @@ package ch.epfl.sweng.zuluzulu.Structure;
 
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -23,6 +24,8 @@ public final class AuthenticatedUser extends User {
 
     // TODO: Get data from cloud service using the id
     protected AuthenticatedUser(String sciper, String gaspar, String email, String first_names, String last_names) {
+        super();
+
         this.sciper = sciper;
         this.gaspar = gaspar;
         this.email = email;
@@ -33,6 +36,9 @@ public final class AuthenticatedUser extends User {
         chats_names = new HashSet<>();
         events_id = Sets.newHashSet(1);
 
+        // Add role
+        this.addRole(UserRole.USER);
+        this.addRole(UserRole.MODERATOR);
     }
 
     // TODO: Add a method to add/remove one Association to assos_id, same for chats and events

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/AuthenticatedUser.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/AuthenticatedUser.java
@@ -38,6 +38,11 @@ public class AuthenticatedUser extends User {
 
         // Add role
         this.addRole(UserRole.USER);
+
+        // TO REMOVE
+        if(gaspar.equals("dahn")){
+            this.addRole(UserRole.ADMIN);
+        }
     }
 
     // TODO: Add a method to add/remove one Association to assos_id, same for chats and events

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/Guest.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/Guest.java
@@ -2,6 +2,13 @@ package ch.epfl.sweng.zuluzulu.Structure;
 
 public final class Guest extends User {
     protected Guest() {
+        super();
+    }
+
+    @Override
+    public boolean hasRole(UserRole role){
+        // Should never have role
+        return false;
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
@@ -157,11 +157,7 @@ abstract public class User implements Serializable {
          * @return AuthenticatedUser or null
          */
         public AuthenticatedUser buildAuthenticatedUser() {
-            if (this.sciper != null
-                    && this.email != null
-                    && this.gaspar != null
-                    && this.first_names != null
-                    && this.last_names != null) {
+            if (hasRequirementsForAuthentication()) {
                 return new AuthenticatedUser(this.sciper, this.gaspar, this.email, this.first_names, this.last_names);
             }
 
@@ -174,11 +170,7 @@ abstract public class User implements Serializable {
          * @return Admin or null
          */
         public Admin buildAdmin() {
-            if (this.sciper != null
-                    && this.email != null
-                    && this.gaspar != null
-                    && this.first_names != null
-                    && this.last_names != null) {
+            if (hasRequirementsForAuthentication()) {
                 return new Admin(this.sciper, this.gaspar, this.email, this.first_names, this.last_names);
             }
 
@@ -192,6 +184,18 @@ abstract public class User implements Serializable {
          */
         public Guest buildGuestUser() {
             return new Guest();
+        }
+
+        /**
+         * Check the requirements for authentication
+         * @return boolean
+         */
+        private boolean hasRequirementsForAuthentication(){
+            return  this.sciper != null
+                    && this.email != null
+                    && this.gaspar != null
+                    && this.first_names != null
+                    && this.last_names != null;
         }
 
     }

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
@@ -5,6 +5,9 @@ import java.util.ArrayList;
 
 abstract public class User implements Serializable {
 
+    /**
+     * This list will contain the roles of the User
+     */
     final protected ArrayList<UserRole> roles;
 
     protected User() {
@@ -32,10 +35,19 @@ abstract public class User implements Serializable {
         return null;
     }
 
+    /**
+     * Check if the user has the role
+     * @param role UserRole
+     * @return boolean
+     */
     public boolean hasRole(UserRole role){
         return roles.contains(role);
     }
 
+    /**
+     * Add the role to the user roles list
+     * @param role UserRole
+     */
     protected void addRole(UserRole role){
         this.roles.add(role);
     }

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
@@ -1,8 +1,16 @@
 package ch.epfl.sweng.zuluzulu.Structure;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 abstract public class User implements Serializable {
+
+    final protected ArrayList<UserRole> roles;
+
+    protected User() {
+        this.roles = new ArrayList<UserRole>();
+    }
+
 
     public String getFirstNames() {
         return null;
@@ -24,6 +32,13 @@ abstract public class User implements Serializable {
         return null;
     }
 
+    public boolean hasRole(UserRole role){
+        return roles.contains(role);
+    }
+
+    protected void addRole(UserRole role){
+        this.roles.add(role);
+    }
 
     public abstract boolean isConnected();
 

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/User.java
@@ -169,6 +169,23 @@ abstract public class User implements Serializable {
         }
 
         /**
+         * Build an Admin
+         *
+         * @return Admin or null
+         */
+        public Admin buildAdmin() {
+            if (this.sciper != null
+                    && this.email != null
+                    && this.gaspar != null
+                    && this.first_names != null
+                    && this.last_names != null) {
+                return new Admin(this.sciper, this.gaspar, this.email, this.first_names, this.last_names);
+            }
+
+            return null;
+        }
+
+        /**
          * Build guest user
          *
          * @return Guest

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/UserRole.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/UserRole.java
@@ -1,0 +1,5 @@
+package ch.epfl.sweng.zuluzulu.Structure;
+
+public enum UserRole {
+    USER, MODERATOR, ADMIN
+}

--- a/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/UserRole.java
+++ b/app/src/main/java/ch/epfl/sweng/zuluzulu/Structure/UserRole.java
@@ -1,5 +1,8 @@
 package ch.epfl.sweng.zuluzulu.Structure;
 
+/**
+ * This enum represent the differents roles for the user
+ */
 public enum UserRole {
     USER, MODERATOR, ADMIN
 }

--- a/app/src/test/java/ch/epfl/sweng/zuluzulu/UserTest.java
+++ b/app/src/test/java/ch/epfl/sweng/zuluzulu/UserTest.java
@@ -45,7 +45,7 @@ public class UserTest {
 
         AuthenticatedUser user = (AuthenticatedUser) builder.build();
 
-        assert(user != null);
+        assertNotNull(user);
 
         return user;
     }
@@ -59,15 +59,17 @@ public class UserTest {
     @Test
     public void canCreateAdmin(){
         User.UserBuilder builder = new User.UserBuilder();
-        builder.setEmail("mail@epfl.ch");
-        builder.setSciper("1212");
-        builder.setGaspar("test");
-        builder.setFirst_names("first_name");
-        builder.setLast_names("last_name");
+        builder.setEmail("admin@epfl.ch");
+        builder.setSciper("121212");
+        builder.setGaspar("admin");
+        builder.setFirst_names("admin_first_name");
+        builder.setLast_names("admin_last_name");
 
         AuthenticatedUser user = (AuthenticatedUser) builder.buildAdmin();
 
+
         assertNotNull(user);
+        assertTrue(user.isConnected());
         assertTrue(user.hasRole(UserRole.ADMIN));
     }
 

--- a/app/src/test/java/ch/epfl/sweng/zuluzulu/UserTest.java
+++ b/app/src/test/java/ch/epfl/sweng/zuluzulu/UserTest.java
@@ -15,6 +15,7 @@ import ch.epfl.sweng.zuluzulu.Structure.UserRole;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -34,7 +35,7 @@ public class UserTest {
         when(event.getId()).thenReturn(2);
     }
 
-    private User createAuthenticatedUser(){
+    private AuthenticatedUser createAuthenticatedUser(){
         User.UserBuilder builder = new User.UserBuilder();
         builder.setEmail("mail@epfl.ch");
         builder.setSciper("1212");
@@ -49,9 +50,25 @@ public class UserTest {
         return user;
     }
 
+    @Test
     public void checkUserRole(){
         User user = createAuthenticatedUser();
         assertTrue(user.hasRole(UserRole.USER));
+    }
+
+    @Test
+    public void canCreateAdmin(){
+        User.UserBuilder builder = new User.UserBuilder();
+        builder.setEmail("mail@epfl.ch");
+        builder.setSciper("1212");
+        builder.setGaspar("test");
+        builder.setFirst_names("first_name");
+        builder.setLast_names("last_name");
+
+        AuthenticatedUser user = (AuthenticatedUser) builder.buildAdmin();
+
+        assertNotNull(user);
+        assertTrue(user.hasRole(UserRole.ADMIN));
     }
 
     @Test
@@ -100,14 +117,7 @@ public class UserTest {
 
     @Test
     public void authenticatedUserCanChangeFavAssos() {
-        User.UserBuilder builder = new User.UserBuilder();
-        builder.setEmail("mail@epfl.ch");
-        builder.setSciper("1212");
-        builder.setGaspar("test");
-        builder.setFirst_names("first_name");
-        builder.setLast_names("last_name");
-        AuthenticatedUser user = (AuthenticatedUser) builder.build();
-
+        AuthenticatedUser user = createAuthenticatedUser();
         assertFalse(user.isFavAssociation(asso));
         assertTrue(user.addFavAssociation(asso));
         assertFalse(user.addFavAssociation(asso));
@@ -138,13 +148,7 @@ public class UserTest {
 
     @Test
     public void authenticatedUserCanChangeFollowedChannels() {
-        User.UserBuilder builder = new User.UserBuilder();
-        builder.setEmail("mail@epfl.ch");
-        builder.setSciper("1212");
-        builder.setGaspar("test");
-        builder.setFirst_names("first_name");
-        builder.setLast_names("last_name");
-        AuthenticatedUser user = (AuthenticatedUser) builder.build();
+        AuthenticatedUser user = createAuthenticatedUser();
 
         assertFalse(user.isFollowedChat(channel));
         assertTrue(user.addFollowedChat(channel));
@@ -157,13 +161,7 @@ public class UserTest {
 
     @Test
     public void toStringIsCorrect() {
-        User.UserBuilder builder = new User.UserBuilder();
-        builder.setEmail("mail@epfl.ch");
-        builder.setSciper("1212");
-        builder.setGaspar("test");
-        builder.setFirst_names("first_name");
-        builder.setLast_names("last_name");
-        AuthenticatedUser user = (AuthenticatedUser) builder.build();
+        User user = createAuthenticatedUser();
 
         String expected = "first_name last_name"
                 + "\nsciper: 1212"

--- a/app/src/test/java/ch/epfl/sweng/zuluzulu/UserTest.java
+++ b/app/src/test/java/ch/epfl/sweng/zuluzulu/UserTest.java
@@ -11,6 +11,7 @@ import ch.epfl.sweng.zuluzulu.Structure.Channel;
 import ch.epfl.sweng.zuluzulu.Structure.Event;
 import ch.epfl.sweng.zuluzulu.Structure.Guest;
 import ch.epfl.sweng.zuluzulu.Structure.User;
+import ch.epfl.sweng.zuluzulu.Structure.UserRole;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,8 +34,7 @@ public class UserTest {
         when(event.getId()).thenReturn(2);
     }
 
-    @Test
-    public void canCreateAuthenticatedUser() {
+    private User createAuthenticatedUser(){
         User.UserBuilder builder = new User.UserBuilder();
         builder.setEmail("mail@epfl.ch");
         builder.setSciper("1212");
@@ -43,6 +43,20 @@ public class UserTest {
         builder.setLast_names("last_name");
 
         AuthenticatedUser user = (AuthenticatedUser) builder.build();
+
+        assert(user != null);
+
+        return user;
+    }
+
+    public void checkUserRole(){
+        User user = createAuthenticatedUser();
+        assertTrue(user.hasRole(UserRole.USER));
+    }
+
+    @Test
+    public void canCreateAuthenticatedUser() {
+        User user = createAuthenticatedUser();
         assertTrue(user.isConnected());
 
         assertEquals(user.getEmail(), "mail@epfl.ch");


### PR DESCRIPTION
For issue #87

Added : 

- Enum `UserRole` that will contain the possibles roles for the User
- An user has now a `roles` list
- We can add a role to a User from a child with `addRole(UserRole role)`
- We can check security from any fragment with `boolean hasRole(UserRole role)` (ex : `user.hasRole(UserRole.MODERATOR)`)
- Added class `Admin`. This class add the role `UserRole.ADMIN`.
- ProfileFragment has now a different output for admins

Internal work :

- Add tests for the Admin and the Roles in `UserTest.java`

Now it's very easy to add a moderator for instance, just add the role `UserRole.MODERATOR` to an user !