### PR TITLE
fixed eventdetailfragmenttest

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/zuluzulu/EventDetailFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/zuluzulu/EventDetailFragmentTest.java
@@ -1,21 +1,18 @@
 package ch.epfl.sweng.zuluzulu;
 
-import android.support.test.espresso.action.ViewActions;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import ch.epfl.sweng.zuluzulu.Fragments.EventFragment;
 import ch.epfl.sweng.zuluzulu.TestingUtility.TestWithAuthenticatedAndFragment;
-
 import static android.support.test.espresso.Espresso.*;
+import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.anything;
 
 @RunWith(AndroidJUnit4.class)
 public class EventDetailFragmentTest extends TestWithAuthenticatedAndFragment<EventFragment> {
@@ -31,22 +28,8 @@ public class EventDetailFragmentTest extends TestWithAuthenticatedAndFragment<Ev
     public void initFragment() {
         fragment = EventFragment.newInstance(user);
     }
-    /*private void guestGoesToEventDetail() throws InterruptedException {
-        Utility.goToEvent();
-        TimeUnit.SECONDS.sleep(1);
-    }
 
-    private void authenticatedGoesToEvent() throws InterruptedException {
-        Utility.fullLogin();
-        Utility.goToEvent();
-        TimeUnit.SECONDS.sleep(1);
-    }
-
-    public void EventDetailFragmentIsOpen() {
-        Utility.checkFragmentIsOpen(1);
-    }
-}
-*/  public void waitABit(){
+    public void waitABit(){
         try{
             Thread.sleep(3000);
         }catch (Exception e){
@@ -58,33 +41,23 @@ public class EventDetailFragmentTest extends TestWithAuthenticatedAndFragment<Ev
     @Test
     public void authenticatedCanOpenAnEvent(){
         waitABit();
-        onView(withText("ForumEPFL")).perform(ViewActions.click());
-        onView(withId(R.id.event_detail_fav))
-                .check(matches(isDisplayed()));
+        onData(anything()).inAdapterView(withId(R.id.event_fragment_listview)).atPosition(0).perform(click());
+        onView(withId(R.id.event_detail_fav)).check(matches(isDisplayed()));
     }
 
-    /*@Test
-    public void guestCanClickOnFavorite() {
-        onView(withText("ForumEPFL")).perform(ViewActions.click());
-        onView(withContentDescription(NOT_FAV_CONTENT))
-                .check(matches(isDisplayed()))
-                .perform(ViewActions.click());
-        onView(withContentDescription(NOT_FAV_CONTENT))
-                .check(matches(isDisplayed()));
-    }*/
    @Test
     public void authenticatedCanOpenTheChatOfAnEvent() {
         waitABit();
-        onView(withText("Hacking Contest!")).perform(ViewActions.click());
-        onView(withId(R.id.event_detail_chatRoom)).perform(ViewActions.click());
+        onData(anything()).inAdapterView(withId(R.id.event_fragment_listview)).atPosition(0).perform(click());
+        onView(withId(R.id.event_detail_chatRoom)).perform(click());
         onView(withId(R.id.chat_send_button)).check(matches(isDisplayed()));
     }
 
     @Test
     public void authenticatedCanOpenTheAssociationOfAnEvent() {
         waitABit();
-        onView(withText("Hacking Contest!")).perform(ViewActions.click());
-        onView(withId(R.id.event_detail_but_assos)).perform(ViewActions.click());
+        onData(anything()).inAdapterView(withId(R.id.event_fragment_listview)).atPosition(0).perform(click());
+        onView(withId(R.id.event_detail_but_assos)).perform(click());
         Utility.checkFragmentIsOpen(R.id.association_detail_fragment);
     }
 


### PR DESCRIPTION
…stead of a precise name

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I modified the eventdetailfragmenttest so that instead selecting an event with a specific name it 
selects the first element of the listView to do the tests on.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue #229 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The previous test depended on the fact a certain specific event existed. Now the test will pass no matter
what event is in the list

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
it is a change in the tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
